### PR TITLE
Add i386 arch and 32-bit libs for libtbb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM        ubuntu:18.04
 
 LABEL       author="mrkrabs" maintainer="bl4ckspr4y@protonmail.com"
 
-RUN         apt update \
+RUN         dpkg --add-architecture i386 \
+            && apt update \
             && apt upgrade -y \
-            && apt install -y libstdc++6 lib32stdc++6 tar curl iproute2 openssl libtbb2 \
+            && apt install -y libstdc++6 lib32stdc++6 tar curl iproute2 openssl \
+            && apt install -y libtbb2:i386 libtbb-dev:i386 \
             && useradd -d /home/container -m container
 
 USER        container


### PR DESCRIPTION
Since SA-MP is running with 32-bit libtbb should be installed with :i386. 
Libtbb enables compatibility with routeconnector.so