### PR TITLE
Add compat-libstdc++-33-3.2.3-61.i386

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN         dpkg --add-architecture i386 \
             && apt-get update \
             && apt-get upgrade -y \
             && apt-get install -y tar curl gcc g++ lib32gcc1 libgcc1 libcurl4-gnutls-dev:i386 libcurl4:i386 lib32tinfo5 libtinfo5:i386 lib32z1 libstdc++6 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libreadline5 libncursesw5 lib32ncursesw5 iproute2 gdb libsdl1.2debian libfontconfig telnet net-tools netcat libtcmalloc-minimal4:i386 \
-            && wget http://ftp.pbone.net/mirror/www.startcom.org/AS-5.0.0/updates/i386/compat-libstdc++-33-3.2.3-61.i386.rpm \
+            && curl http://ftp.pbone.net/mirror/www.startcom.org/AS-5.0.0/updates/i386/compat-libstdc++-33-3.2.3-61.i386.rpm \
             && rpm -ihw --nodeps compat-libstdc++-33-3.2.3-61.i386.rpm
             && useradd -m -d /home/container container
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV         DEBIAN_FRONTEND noninteractive
 RUN         dpkg --add-architecture i386 \
             && apt-get update \
             && apt-get upgrade -y \
-            && apt-get install -y tar curl gcc g++ lib32gcc1 libgcc1 libcurl4-gnutls-dev:i386 libcurl4:i386 lib32tinfo5 libtinfo5:i386 lib32z1 libstdc++6 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libreadline5 libncursesw5 lib32ncursesw5 iproute2 gdb libsdl1.2debian libfontconfig telnet net-tools netcat libtcmalloc-minimal4:i386 \
+            && apt-get install -y tar curl gcc g++ lib32gcc1 libgcc1 libcurl4-gnutls-dev:i386 libcurl4:i386 lib32tinfo5 libtinfo5:i386 lib32z1 libstdc++6 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libreadline5 libncursesw5 lib32ncursesw5 iproute2 gdb libsdl1.2debian libfontconfig telnet net-tools netcat libtcmalloc-minimal4:i386 faketime \
             && wget http://ftp.pbone.net/mirror/www.startcom.org/AS-5.0.0/updates/i386/compat-libstdc++-33-3.2.3-61.i386.rpm \
             && rpm -ihw --nodeps compat-libstdc++-33-3.2.3-61.i386.rpm
             && useradd -m -d /home/container container

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN         dpkg --add-architecture i386 \
             && apt-get update \
             && apt-get upgrade -y \
             && apt-get install -y tar curl gcc g++ lib32gcc1 libgcc1 libcurl4-gnutls-dev:i386 libcurl4:i386 lib32tinfo5 libtinfo5:i386 lib32z1 libstdc++6 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libreadline5 libncursesw5 lib32ncursesw5 iproute2 gdb libsdl1.2debian libfontconfig telnet net-tools netcat libtcmalloc-minimal4:i386 \
-            && curl http://ftp.pbone.net/mirror/www.startcom.org/AS-5.0.0/updates/i386/compat-libstdc++-33-3.2.3-61.i386.rpm \
+            && wget http://ftp.pbone.net/mirror/www.startcom.org/AS-5.0.0/updates/i386/compat-libstdc++-33-3.2.3-61.i386.rpm \
             && rpm -ihw --nodeps compat-libstdc++-33-3.2.3-61.i386.rpm
             && useradd -m -d /home/container container
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN         dpkg --add-architecture i386 \
             && apt-get update \
             && apt-get upgrade -y \
             && apt-get install -y tar curl gcc g++ lib32gcc1 libgcc1 libcurl4-gnutls-dev:i386 libcurl4:i386 lib32tinfo5 libtinfo5:i386 lib32z1 libstdc++6 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libreadline5 libncursesw5 lib32ncursesw5 iproute2 gdb libsdl1.2debian libfontconfig telnet net-tools netcat libtcmalloc-minimal4:i386 \
+            && wget http://ftp.pbone.net/mirror/www.startcom.org/AS-5.0.0/updates/i386/compat-libstdc++-33-3.2.3-61.i386.rpm \
+            && rpm -ihw --nodeps compat-libstdc++-33-3.2.3-61.i386.rpm
             && useradd -m -d /home/container container
 
 USER        container


### PR DESCRIPTION
It is required for some older HLDS addons (.so files) that need this library to work.

Only wget seems to work, as curl throws some wacky error when attempting to download that rpm file through it.