### PR TITLE
fix youtube-dl is too old with Debian Package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN   apt update \
  &&   apt upgrade -y
 
 ##    install dependencies
-RUN   apt install -y ffmpeg youtube-dl
+RUN   apt install -y ffmpeg curl python3 python3-pip
+RUN   pip3 install --upgrade youtube_dl
 
 COPY  ./entrypoint.sh /entrypoint.sh
 CMD   ["/bin/bash", "/entrypoint.sh"]


### PR DESCRIPTION
Now the latest youtube-dl is used. The Debian Package is outdated and casues Errors