### PR TITLE
Add tzdata dependency to fix timezone issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN         dpkg --add-architecture i386 \
             && apt update \
             && apt upgrade -y \
             && apt install -y libstdc++6 lib32stdc++6 tar curl iproute2 openssl \
-            && apt install -y libtbb2:i386 libtbb-dev:i386 libicu-dev:i386 \
+            && apt install -y libtbb2:i386 libtbb-dev:i386 libicu-dev:i386 tzdata \
             && useradd -d /home/container -m container
 
 USER        container


### PR DESCRIPTION
I added tzdata package so timezone is correct, as mentioned in https://github.com/pterodactyl/panel/issues/2748, for SA-MP egg.