### PR TITLE
Arma 3 - Add Support for Legacy Eggs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,8 +78,8 @@ then
 	done
 fi
 
-# Check if specified server binary exists
-if [[ ! -f ./${SERVER_BINARY} ]];
+# Check if specified server binary exists. If null (legacy egg is being used), skips check.
+if [[ -n ${SERVER_BINARY} ]] && [[ ! -f ./${SERVER_BINARY} ]];
 then
 	echo -e "\n${RED}STARTUP_ERR: Specified server binary could not be found in files! Verify your Server Binary startup variable.${NC}"
 	exit 1


### PR DESCRIPTION
Added support for legacy eggs, where if the new variable SERVER_BINARY is missing, it skips the server binary file check. This prevents older eggs from crashing on boot.