### PR TITLE
uMod - Debian Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:18.04
+
+MAINTAINER CastBlacKing, <thewagaming@gmail.com>
+
+RUN apt update && apt upgrade -y
+RUN apt install -y wget sudo curl tar zip unzip sed apt-utils ca-certificates
+RUN wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && dpkg -i packages-microsoft-prod.deb && apt update -y && apt install -y dotnet-sdk-5.0 aspnetcore-runtime-5.0 libgdiplus
+
+RUN adduser -disabled-password -home /home/container container
+
+USER container
+ENV USER=container HOME=/home/container
+WORKDIR /home/container
+
+RUN dotnet tool update uMod --version "*-*" --global --add-source https://www.myget.org/f/umod/api/v3/index.json
+RUN dotnet new -i "uMod.Templates::*-*" --nuget-source https://www.myget.org/f/umod/api/v3/index.json &>/dev/null
+
+RUN export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+RUN echo "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1; export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT" >> ~/.profile
+RUN export PATH="$PATH:$HOME/.dotnet/tools"
+RUN export PATH="$PATH:/home/container/.dotnet/tools"
+RUN echo "PATH=\$PATH:\$HOME/.dotnet/tools; export PATH" >> ~/.profile
+
+RUN ~/.dotnet/tools/umod complete --install
+
+COPY ./entrypoint.sh /entrypoint.sh
+CMD ["/bin/bash", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,16 @@ LABEL author="CastBlacKing" maintainer="thewagaming@gmail.com"
 ENV DEBIAN_FRONTEND noninteractive
 
 ## update base packages
-RUN apt update && apt upgrade -y \
-&& apt install -y wget sudo curl tar zip unzip sed apt-utils ca-certificates \
-&& wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
-&& dpkg -i packages-microsoft-prod.deb \
-&& apt install -y dotnet-sdk-5.0 aspnetcore-runtime-5.0 libgdiplus
+RUN apt update -y \
+    && apt upgrade -y \
+    && apt install -y wget sudo curl tar zip unzip sed apt-utils ca-certificates \
+    && wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && apt update -y \  
+    && apt install -y dotnet-sdk-5.0 aspnetcore-runtime-5.0 libgdiplus
 
 ## add container user
-RUN useradd -m -d /home/container -s /bin/bash container
+USER    container
 RUN ln -s /home/container/ /nonexistent
 ENV USER=container HOME=/home/container
 
@@ -26,15 +28,11 @@ RUN dotnet new -i "uMod.Templates::*-*" --nuget-source https://www.myget.org/f/u
 
 # Path to .profile
 RUN export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 \
-&& echo "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1; export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT" >> ~/.profile \
-&& export PATH="$PATH:$HOME/.dotnet/tools" \
-&& export PATH="$PATH:/home/container/.dotnet/tools" \ 
-&& echo "PATH=\$PATH:\$HOME/.dotnet/tools; export PATH" >> ~/.profile\
-&& ~/.dotnet/tools/umod complete --install
-
-## configure locale
-RUN update-locale lang=en_US.UTF-8 \
- && dpkg-reconfigure --frontend noninteractive locales
+    && echo "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1; export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT" >> ~/.profile \
+    && export PATH="$PATH:$HOME/.dotnet/tools" \
+    && export PATH="$PATH:/home/container/.dotnet/tools" \ 
+    && echo "PATH=\$PATH:\$HOME/.dotnet/tools; export PATH" >> ~/.profile \
+    && ~/.dotnet/tools/umod complete --install
 
 WORKDIR /home/container
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Environment: debian:buster-slim
 # Minimum Panel Version: 0.7.X
 # ----------------------------------
-FROM ubuntu:18.04
+FROM quay.io/parkervcp/pterodactyl-images:base_debian
 
 LABEL author="CastBlacKing" maintainer="thewagaming@gmail.com"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+cd /home/container
+
+#Umod
+export PATH="$PATH:$HOME/.dotnet/tools"
+echo "PATH=\$PATH:\$HOME/.dotnet/tools; export PATH" >> ~/.profile
+
+# fixes Couldn't find a valid ICU package installed on the system
+export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+echo "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1; export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT" >> ~/.profile
+
+# Update Valheim Server
+umod update core apps extensions --patch-available --strict --validate --prerelease
+
+#Run Server
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
+
+# Replace Startup Variables
+MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
+echo ":/home/container$ ${MODIFIED_STARTUP}"
+
+# Run the Server
+${MODIFIED_STARTUP}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ export PATH="$PATH:$HOME/.dotnet/tools"
 export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
 
-# Update Valheim and uMod
+## Update Valheim and uMod
 if [[ ${AUTO_UPDATE} == "1" ]] && [[ ${UPDATE_PLUGINS} == "1" ]]; then
         if [[ ! -z ${INSTALL_PLUGINS} ]]; then
         echo -e "STARTUP: Plugins configured, installing Plugins: ${INSTALL_PLUGINS}"
@@ -20,13 +20,14 @@ if [[ ${AUTO_UPDATE} == "1" ]] && [[ ${UPDATE_PLUGINS} == "1" ]]; then
     echo -e "STARTUP: Game server and uMod update is complete!"
 fi
 
-#
+# AutoUpdate All
 if [[ ${AUTO_UPDATE} == "1" ]] && [[ ${UPDATE_PLUGINS} == "0" ]]; then
     echo -e "STARTUP: Updating game and uMod, ignoring plugin updates as update plugins is set to 0..."
     umod update -P game core apps extensions --patch-available --strict
     echo -e "STARTUP: Game server and uMod update is complete!"
 fi
 
+# AutoUpdate Plugins
 if [[ ${AUTO_UPDATE} == "0" ]] && [[ ${UPDATE_PLUGINS} == "1" ]]; then
     if [[ ! -z ${INSTALL_PLUGINS} ]]; then
     echo -e "STARTUP: Found configured Plugins, checking if they are not installed: ${INSTALL_PLUGINS}"
@@ -38,10 +39,12 @@ if [[ ${AUTO_UPDATE} == "0" ]] && [[ ${UPDATE_PLUGINS} == "1" ]]; then
     echo -e "STARTUP: Plugin updates are completed!"
 fi
 
+# AutoUpdate Not Update Notice
 if [[ ${AUTO_UPDATE} == "0" ]] && [[ ${UPDATE_PLUGINS} == "0" ]]; then
     echo "STARTUP: Not performing any updates as auto-update is set to 0 (disabled). Starting Server"
 fi
 
+# Installing Plugins
 if [[ ! -z ${INSTALL_PLUGINS} ]]; then
     echo -e "STARTUP: Found configured Plugins, installing Plugins: ${INSTALL_PLUGINS}"
     umod require ${INSTALL_PLUGINS} 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,23 +1,63 @@
 #!/bin/bash
 cd /home/container
 
-#Umod
+# This entrypoint.sh is a modification of the entrypoint made by: Software-Noob, to him credit for making differential Auto-Update scheme.
+
+# Exporting: Dotnet Path / Library Path (Umod error prevent)
 export PATH="$PATH:$HOME/.dotnet/tools"
-echo "PATH=\$PATH:\$HOME/.dotnet/tools; export PATH" >> ~/.profile
-
-# fixes Couldn't find a valid ICU package installed on the system
 export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
-echo "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1; export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT" >> ~/.profile
-
-# Update Valheim Server
-umod update core apps extensions --patch-available --strict --validate --prerelease
-
-#Run Server
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
 
+# Update Valheim and uMod
+if [[ ${AUTO_UPDATE} == "1" ]] && [[ ${UPDATE_PLUGINS} == "1" ]]; then
+        if [[ ! -z ${INSTALL_PLUGINS} ]]; then
+        echo -e "STARTUP: Plugins configured, installing Plugins: ${INSTALL_PLUGINS}"
+        umod require ${INSTALL_PLUGINS} 
+        echo -e "STARTUP: Plugin installation is completed!"
+        fi
+    echo -e "STARTUP: Checking for game and plugins updates..."
+    umod update -P all --patch-available
+    echo -e "STARTUP: Game server and uMod update is complete!"
+fi
+
+#
+if [[ ${AUTO_UPDATE} == "1" ]] && [[ ${UPDATE_PLUGINS} == "0" ]]; then
+    echo -e "STARTUP: Updating game and uMod, ignoring plugin updates as update plugins is set to 0..."
+    umod update -P game core apps extensions --patch-available --strict
+    echo -e "STARTUP: Game server and uMod update is complete!"
+fi
+
+if [[ ${AUTO_UPDATE} == "0" ]] && [[ ${UPDATE_PLUGINS} == "1" ]]; then
+    if [[ ! -z ${INSTALL_PLUGINS} ]]; then
+    echo -e "STARTUP: Found configured Plugins, checking if they are not installed: ${INSTALL_PLUGINS}"
+    umod require ${INSTALL_PLUGINS} 
+    echo -e "STARTUP: Plugin installation is completed!"
+    fi
+    echo -e "STARTUP: Updating plugins, ignoring game and uMod updates as auto update is set to 0..."
+    umod update plugins
+    echo -e "STARTUP: Plugin updates are completed!"
+fi
+
+if [[ ${AUTO_UPDATE} == "0" ]] && [[ ${UPDATE_PLUGINS} == "0" ]]; then
+    echo "STARTUP: Not performing any updates as auto-update is set to 0 (disabled). Starting Server"
+fi
+
+if [[ ! -z ${INSTALL_PLUGINS} ]]; then
+    echo -e "STARTUP: Found configured Plugins, installing Plugins: ${INSTALL_PLUGINS}"
+    umod require ${INSTALL_PLUGINS} 
+    echo -e "STARTUP: Plugin installation is completed!"
+fi
+
+
+# Cleanup non-required startups
+if [ -f start_server.sh ]; then
+rm umod-install.sh start_server.sh start_server_xterm.sh launcher.sh
+rm "Valheim Dedicated Server Manual.pdf"
+fi
+
 # Replace Startup Variables
-MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
-echo ":/home/container$ ${MODIFIED_STARTUP}"
+MODIFIED_STARTUP=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
+echo -e ":/home/container$ ${MODIFIED_STARTUP}"
 
 # Run the Server
-${MODIFIED_STARTUP}
+eval ${MODIFIED_STARTUP}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ export PATH="$PATH:$HOME/.dotnet/tools"
 export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
 
-## Update Valheim and uMod
+## Update Game and uMod
 if [[ ${AUTO_UPDATE} == "1" ]] && [[ ${UPDATE_PLUGINS} == "1" ]]; then
         if [[ ! -z ${INSTALL_PLUGINS} ]]; then
         echo -e "STARTUP: Plugins configured, installing Plugins: ${INSTALL_PLUGINS}"


### PR DESCRIPTION
This image was created for the use of uMod, it serves not only for Valheim, but also for other games that will be supported by the uMod compiler in the future, such as Rust.

Inside this image is installed:

- DotNet 5.0
- uMod

Entrypoint.sh sets PATHs for uMod and DotNet, automatically updates the Server, Plugins and Core (By SoftwareNoob) and finally starts the server.

Again, entrypoint.sh is not only for Valheim, but with some modifications, it will work for all games that use uMod.

Dockerhub Repository: https://hub.docker.com/repository/docker/castblacking/umod-valheim

**To Parkervcp:**
Read the message I left for you at: https://github.com/parkervcp/eggs/pull/1010