### PR TITLE
Pavlov VR Image Change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,8 @@ RUN apt update \
  && apt upgrade -y
 
 ## install dependencies
-RUN apt install -y gcc g++ libgcc1 lib32gcc1 gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
+RUN apt install -y gcc g++ libgcc1 lib32gcc1 libc++-dev gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
     libfontconfig libicu63 icu-devtools libunwind8 libssl-dev sqlite3 libsqlite3-dev libmariadbclient-dev libduktape203 locales ffmpeg gnupg2 apt-transport-https software-properties-common ca-certificates tzdata
-
-## PAVLOV REQUIREMENT
-RUN apt install -y libc++-dev
 
 ## configure locale
 RUN update-locale lang=en_US.UTF-8 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN apt update \
 RUN apt install -y gcc g++ libgcc1 lib32gcc1 gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
     libfontconfig libicu63 icu-devtools libunwind8 libssl-dev sqlite3 libsqlite3-dev libmariadbclient-dev libduktape203 locales ffmpeg gnupg2 apt-transport-https software-properties-common ca-certificates tzdata
 
+## PAVLOV REQUIREMENT
+RUN apt install -y libc++-dev
+
 ## configure locale
 RUN update-locale lang=en_US.UTF-8 \
  && dpkg-reconfigure --frontend noninteractive locales


### PR DESCRIPTION
Pavlov VR unfortunately requires a specific libc++-dev package in the server container in order to run. 
There was two fixes found, one was to download a bunch of "sketchy" files into the container. The other was to add libc++-dev into the container. I think the latter is much cleaner and a better way of doing it. All it requires is the base/debian dockerfile with libc++-dev added.

There is a pending PR for the egg, which needs to be changed depending on what happens with this image PR.
https://github.com/parkervcp/eggs/pull/904

In which I was recommended to just PR the change requirement to the base/debian package, as unfortunately github doesn't seem to support PRing into new branches.
https://github.com/parkervcp/eggs/pull/904#issuecomment-803254196