### PR TITLE
Arma "User Error Prevention" Patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN         dpkg --add-architecture i386 \
             && apt-get update \
             && apt-get upgrade -y \
             && apt-get install -y libgcc-10-dev libstdc++-10-dev libtinfo5 lib64z1 libcurl3-gnutls \
-            && apt-get install -y libnss-wrapper gettext-base tar curl gcc g++ libc6 libtbb2 lib32z1 lib32gcc1 lib32stdc++6 libsdl2-2.0-0:i386 libtbb2:i386 lib32stdc++6 libtinfo5:i386 libncurses5:i386 libcurl3-gnutls:i386 \
+            && apt-get install -y libnss-wrapper gettext-base tar curl gcc g++ libc6 libtbb2 lib32z1 lib32gcc1 lib32stdc++6 libsdl2-2.0-0 libsdl2-2.0-0:i386 libtbb2:i386 lib32stdc++6 libtinfo5:i386 libncurses5:i386 libcurl3-gnutls:i386 \
             && useradd -m -d /home/container -s /bin/bash container \
             && touch ${NSS_WRAPPER_PASSWD} ${NSS_WRAPPER_GROUP} \
             && chgrp 0 ${NSS_WRAPPER_PASSWD} ${NSS_WRAPPER_GROUP} \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ ModsLowercase () {
 }
 
 # Check for old eggs
-if [[ -z ${SERVER_BINARY} ]] || [[ -n ${MODS} ]] || [[ ! -e ${WORKSHOP_BLACKLIST}]];
+if [[ -z ${SERVER_BINARY} ]] || [[ -n ${MODS} ]] || [[ -z ${WORKSHOP_BLACKLIST}]];
 then
 	echo -e "\n${RED}STARTUP_ERR: Please contact your administrator/host for support, and give them the following message:${NC}\n"
 	echo -e "\t${CYAN}Your Arma 3 Egg is outdated and no longer supported.${NC}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -145,7 +145,7 @@ then
 		then
 			./${SERVER_BINARY} -client -connect=127.0.0.1 -port=${SERVER_PORT} -password="${HC_PASSWORD}" -profiles=./serverprofile -bepath=./battleye -mod="${MODIFICATIONS}" ${STARTUP_PARAMS} > /dev/null 2>&1 &
 		else
-			./${SERVER_BINARY} -client -connect=127.0.0.1 -port=${SERVER_PORT} -password="${HC_PASSWORD}" -profiles=./serverprofile -bepath=./battleye -mod="${MODIFICATIONS}" ${STARTUP_PARAMS}
+			./${SERVER_BINARY} -client -connect=127.0.0.1 -port=${SERVER_PORT} -password="${HC_PASSWORD}" -profiles=./serverprofile -bepath=./battleye -mod="${MODIFICATIONS}" ${STARTUP_PARAMS} &
 		fi
 		echo -e "${GREEN}STARTUP:${CYAN} Headless Client $i${NC} launched."
 	done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ ModsLowercase () {
 }
 
 # Check for old eggs
-if [[ -z ${SERVER_BINARY} ]] || [[ -n ${MODS} ]] || [[ -z ${WORKSHOP_BLACKLIST}]];
+if [[ -z ${SERVER_BINARY} ]] || [[ -n ${MODS} ]] || [[ ! -e ${WORKSHOP_BLACKLIST} ]];
 then
 	echo -e "\n${RED}STARTUP_ERR: Please contact your administrator/host for support, and give them the following message:${NC}\n"
 	echo -e "\t${CYAN}Your Arma 3 Egg is outdated and no longer supported.${NC}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,8 +71,8 @@ then
 		if [[ ",${WORKSHOP_BLACKLIST}," == *,$i,* ]];
 		then
 			echo -e "\n${GREEN}STARTUP:${YELLOW} Skipping the download/update of Steam Workshop mod ID: ${CYAN}$i${NC}"
-			echo -e "\tThe mod is either too large to download or is blacklisted by your host."
-			echo -e "\tTo install this mod, you will have to manually upload it via SFTP, and set the Mod to Lowercase startup variable to 1 for one bootup sequence.\n"
+			echo -e "The mod is either too large to download or is blacklisted by your host."
+			echo -e "To install this mod, you will have to manually upload it via SFTP, and set the Mod to Lowercase startup var to 1 for one bootup sequence.\n"
 		else
 			echo -e "\n${GREEN}STARTUP:${NC} Downloading/Updating Steam Workshop mod ID: ${CYAN}$i${NC}...\n"
 			./steamcmd/steamcmd.sh +login ${STEAM_USER} ${STEAM_PASS} +workshop_download_item $armaGameID $i validate +quit

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ ModsLowercase () {
 }
 
 # Check for old eggs
-if [[ -z ${SERVER_BINARY} ]] || [[ -n ${MODS} ]];
+if [[ -z ${SERVER_BINARY} ]] || [[ -n ${MODS} ]] || [[ ! -e ${WORKSHOP_BLACKLIST}]];
 then
 	echo -e "\n${RED}STARTUP_ERR: Please contact your administrator/host for support, and give them the following message:${NC}\n"
 	echo -e "\t${CYAN}Your Arma 3 Egg is outdated and no longer supported.${NC}"
@@ -70,8 +70,8 @@ then
 	do
 		if [[ ",${WORKSHOP_BLACKLIST}," == *,$i,* ]];
 		then
-			echo -e "\n${GREEN}STARTUP:${YELLOW} Skipping the download/update of Steam Workshop mod ID: ${CYAN}$i${NC}."
-			echo -e "\t${YELLOW}The mod is either too big to download or is blacklisted.${NC}\n"
+			echo -e "\n${GREEN}STARTUP:${YELLOW} Skipping the download/update of Steam Workshop mod ID: ${CYAN}$i${NC}"
+			echo -e "\tThe mod is either too large to download or is blacklisted by your host.\n"
 		else
 			echo -e "\n${GREEN}STARTUP:${NC} Downloading/Updating Steam Workshop mod ID: ${CYAN}$i${NC}...\n"
 			./steamcmd/steamcmd.sh +login ${STEAM_USER} ${STEAM_PASS} +workshop_download_item $armaGameID $i validate +quit

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,6 +39,16 @@ then
 	exit 1
 fi
 
+# Check for improper Steam account set
+if [[ ${STEAM_USER} == "your_steam_username" ]] || [[ ${STEAM_USER} == "anonymous" ]];
+then
+	echo -e "\n${RED}STARTUP_ERR: Please contact your administrator/host for support, and give them the following message:${NC}\n"
+	echo -e "\t${CYAN}Your Arma 3 Egg, or your client's server, is not configured with valid Steam credentials.${NC}"
+	echo -e "\t${CYAN}Please visit the following link for more info:${NC}"
+	echo -e "\t${CYAN}https://github.com/parkervcp/eggs/tree/master/steamcmd_servers/arma/arma3#installation-requirements${NC}\n"
+	exit 1
+fi
+
 # Update dedicated server, if specified
 if [[ ${UPDATE_SERVER} == "1" ]];
 then
@@ -124,7 +134,7 @@ then
 	echo -e "\n${GREEN}STARTUP:${NC} Starting ${CYAN}${HC_NUM}${NC} Headless Client(s)."
 	for i in $(seq ${HC_NUM})
 	do
-		./${SERVER_BINARY} -client -connect=127.0.0.1 -port=${SERVER_PORT} -password="${HC_PASSWORD}" -profiles=./serverprofile -bepath=./battleye -mod="${MODIFICATIONS}" ${STARTUP_PARAMS} &
+		./${SERVER_BINARY} -client -connect=127.0.0.1 -port=${SERVER_PORT} -password="${HC_PASSWORD}" -profiles=./serverprofile -bepath=./battleye -mod="${MODIFICATIONS}" ${STARTUP_PARAMS} > /dev/null 2>&1 &
 		echo -e "${GREEN}STARTUP:${CYAN} Headless Client $i${NC} launched."
 	done
 fi
@@ -136,6 +146,12 @@ ${MODIFIED_STARTUP}
 
 if [ $? -ne 0 ];
 then
-    echo -e "\n${RED}PTDL_CONTAINER_ERR: There was an error while attempting to run the start command.${NC}\n"
-    exit 1
+	echo -e "\n${RED}PTDL_CONTAINER_ERR: There was an error while attempting to run the start command.${NC}\n"
+	exit 1
+else
+	if [[ ${HC_NUM} > 0 ]];
+	then
+		echo -e "\n${GREEN}SHUTDOWN:${NC} Stopping all headless clients...\n"
+		kill $(jobs -p)
+	fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -141,7 +141,12 @@ then
 	echo -e "\n${GREEN}STARTUP:${NC} Starting ${CYAN}${HC_NUM}${NC} Headless Client(s)."
 	for i in $(seq ${HC_NUM})
 	do
-		./${SERVER_BINARY} -client -connect=127.0.0.1 -port=${SERVER_PORT} -password="${HC_PASSWORD}" -profiles=./serverprofile -bepath=./battleye -mod="${MODIFICATIONS}" ${STARTUP_PARAMS} > /dev/null 2>&1 &
+		if [[ ${HC_HIDE} == "1" ]];
+		then
+			./${SERVER_BINARY} -client -connect=127.0.0.1 -port=${SERVER_PORT} -password="${HC_PASSWORD}" -profiles=./serverprofile -bepath=./battleye -mod="${MODIFICATIONS}" ${STARTUP_PARAMS} > /dev/null 2>&1 &
+		else
+			./${SERVER_BINARY} -client -connect=127.0.0.1 -port=${SERVER_PORT} -password="${HC_PASSWORD}" -profiles=./serverprofile -bepath=./battleye -mod="${MODIFICATIONS}" ${STARTUP_PARAMS}
+		fi
 		echo -e "${GREEN}STARTUP:${CYAN} Headless Client $i${NC} launched."
 	done
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ ModsLowercase () {
 }
 
 # Check for old eggs
-if [[ -z ${SERVER_BINARY} ]] || [[ -n ${MODS} ]] || [[ ! -e ${WORKSHOP_BLACKLIST} ]];
+if [[ -z ${SERVER_BINARY} ]] || [[ -n ${MODS} ]] || [[ -z ${WORKSHOP_BLACKLIST} ]];
 then
 	echo -e "\n${RED}STARTUP_ERR: Please contact your administrator/host for support, and give them the following message:${NC}\n"
 	echo -e "\t${CYAN}Your Arma 3 Egg is outdated and no longer supported.${NC}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,18 +68,24 @@ if [[ -n ${UPDATE_WORKSHOP} ]];
 then
 	for i in $(echo -e ${UPDATE_WORKSHOP} | sed "s/,/ /g")
 	do
-		echo -e "\n${GREEN}STARTUP:${NC} Downloading/Updating Steam Workshop mod ID: ${CYAN}$i${NC}...\n"
-		./steamcmd/steamcmd.sh +login ${STEAM_USER} ${STEAM_PASS} +workshop_download_item $armaGameID $i validate +quit
-		# Move the downloaded mod to the root directory, and replace existing mod if needed
-		mkdir -p ./@$i
-		rm -rf ./@$i/*
-		mv -f ./Steam/steamapps/workshop/content/$armaGameID/$i/* ./@$i
-		rm -d ./Steam/steamapps/workshop/content/$armaGameID/$i
-		# Make the mods contents all lowercase
-		ModsLowercase @$i
-		# Move any .bikey's to the keys directory
-		echo -e "\n${GREEN}STARTUP:${NC} Moving any mod .bikey files to the ~/keys/ folder...\n"
-		find ./@$i -name "*.bikey" -type f -exec cp {} ./keys \;
+		if [[ ",${WORKSHOP_BLACKLIST}," == *,$i,* ]];
+		then
+			echo -e "\n${GREEN}STARTUP:${YELLOW} Skipping the download/update of Steam Workshop mod ID: ${CYAN}$i${NC}."
+			echo -e "\t${YELLOW}The mod is either too big to download or is blacklisted.${NC}\n"
+		else
+			echo -e "\n${GREEN}STARTUP:${NC} Downloading/Updating Steam Workshop mod ID: ${CYAN}$i${NC}...\n"
+			./steamcmd/steamcmd.sh +login ${STEAM_USER} ${STEAM_PASS} +workshop_download_item $armaGameID $i validate +quit
+			# Move the downloaded mod to the root directory, and replace existing mod if needed
+			mkdir -p ./@$i
+			rm -rf ./@$i/*
+			mv -f ./Steam/steamapps/workshop/content/$armaGameID/$i/* ./@$i
+			rm -d ./Steam/steamapps/workshop/content/$armaGameID/$i
+			# Make the mods contents all lowercase
+			ModsLowercase @$i
+			# Move any .bikey's to the keys directory
+			echo -e "\n${GREEN}STARTUP:${NC} Moving any mod .bikey files to the ~/keys/ folder...\n"
+			find ./@$i -name "*.bikey" -type f -exec cp {} ./keys \;
+		fi
 	done
 	echo -e "\n${GREEN}STARTUP: Download/Update Steam Workshop mods complete!${NC}\n"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,7 +71,8 @@ then
 		if [[ ",${WORKSHOP_BLACKLIST}," == *,$i,* ]];
 		then
 			echo -e "\n${GREEN}STARTUP:${YELLOW} Skipping the download/update of Steam Workshop mod ID: ${CYAN}$i${NC}"
-			echo -e "\tThe mod is either too large to download or is blacklisted by your host.\n"
+			echo -e "\tThe mod is either too large to download or is blacklisted by your host."
+			echo -e "\tTo install this mod, you will have to manually upload it via SFTP, and set the Mod to Lowercase startup variable to 1 for one bootup sequence.\n"
 		else
 			echo -e "\n${GREEN}STARTUP:${NC} Downloading/Updating Steam Workshop mod ID: ${CYAN}$i${NC}...\n"
 			./steamcmd/steamcmd.sh +login ${STEAM_USER} ${STEAM_PASS} +workshop_download_item $armaGameID $i validate +quit

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -148,10 +148,4 @@ if [ $? -ne 0 ];
 then
 	echo -e "\n${RED}PTDL_CONTAINER_ERR: There was an error while attempting to run the start command.${NC}\n"
 	exit 1
-else
-	if [[ ${HC_NUM} > 0 ]];
-	then
-		echo -e "\n${GREEN}SHUTDOWN:${NC} Stopping all headless clients...\n"
-		kill $(jobs -p)
-	fi
 fi


### PR DESCRIPTION
## Arma 3 Image Pull Request

#### NOTE: This Image update will only perform as intended if it's complimentary Egg Pull Request is also accepted. Please consider only merging this PR at the same time as the Egg PR. Thank you.

### Bug Fixes:
- Added the `libsdl2-2.0-0` package to prevent 64-bit Steam SDL errors when the game server is run.

### Additions:
- Added additional check for outdated eggs.
- Added check to see if the host accidentally left the Steam Username as the default, or set it to `anonymous` thinking it would work.
- Added a Steam Workshop Mod Blacklist to prevent users from attempting to download mods that are known not to download via SteamCMD (due to it's limitations), or deleting already installed mods by accident in the process.
- Modified any running headless clients to output their console to `/dev/null` (and their errors to the main console) to prevent nonessential console spam.
