### PR TITLE
Pavlov Auto update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN dpkg --add-architecture i386 \
  && apt update \
  && apt upgrade -y \
  && apt install -y libssl1.1:i386 libtinfo6:i386 libtbb2:i386 libtinfo5:i386 libcurl4-gnutls-dev:i386 libcurl4:i386 libncurses5:i386 libcurl3-gnutls:i386 libtcmalloc-minimal4:i386 faketime:i386 libtbb2:i386 \
-    lib32tinfo6 lib32stdc++6 lib32z1 libtbb2 libtinfo5 libstdc++6 libreadline5 libncursesw5 libfontconfig1 libnss-wrapper gettext-base
+    lib32tinfo6 lib32stdc++6 lib32z1 libtbb2 libtinfo5 libstdc++6 libreadline5 libncursesw5 libfontconfig1 libnss-wrapper gettext-base libc++-dev
 
 ## install rcon
 RUN cd /tmp/ \


### PR DESCRIPTION
Due to the auto update feature requiring a different setup with the docker image, we are having to change the docker file from Base Debian to Debian Source. This will be the final fix before the Pavlov VR Egg is fully functional and production ready.