### PR TITLE
Docker image for Call of Duty 4X

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:buster-slim
+
+LABEL author="grimsi" maintainer="admin@grimsi.de"
+
+RUN apt-get update && \
+    apt-get install -y \
+            lib32stdc++6 \
+            ca-certificates \
+            iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+
+USER container
+ENV  USER=container HOME=/home/container
+
+WORKDIR /home/container
+
+COPY entrypoint.sh /entrypoint.sh
+
+CMD ["/bin/bash", "/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+cd /home/container
+
+# Make internal Docker IP address available to processes.
+export INTERNAL_IP=`ip route | awk '/default/ { print $3 }'`
+
+# check if the game files are mounted
+if [ ! -d ${GAME_FILE_PATH} ]; then
+	echo "CoD 4 game files not found. Maybe they are not mounted?"
+	echo "In order for the server to start mount the game files here: ${GAME_FILE_PATH}"
+	while true; do sleep 2; done
+else
+	# Replace Startup Variables
+	MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
+	echo ":/home/container$ ${MODIFIED_STARTUP}"
+
+	# Run the Server
+	eval ${MODIFIED_STARTUP}
+fi


### PR DESCRIPTION
This image is required for the Call of Duty 4X egg pull request.
Neither the image nor the egg contain any copyrighted data (that data has to be provided at runtime by the user in the form of a mount).
The image checks if the gamefiles are mounted under a configurable path and outputs a error message if they still need to be mounted.
A more detailed README with instructions on how to use the egg will be in the other pull request (the one for the egg itself).