### PR TITLE
Bump .net Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN     apt update -y \
 RUN     wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
         && dpkg -i packages-microsoft-prod.deb \
         && apt update -y \
-        && apt install -y dotnet-sdk-3.1 aspnetcore-runtime-3.1 libgdiplus \
+        && apt install -y dotnet-sdk-5.0 dotnet-runtime-5.0 libgdiplus \
         && apt install -y ffmpeg iproute2 git sqlite3 python3 ca-certificates dnsutils build-essential \
         && apt install -y coreutils jq pcregrep
 


### PR DESCRIPTION
Bumped dotnet-sdk from 3.1 to 5.0
Added dotnet-runtime-5.0

Closes https://github.com/parkervcp/eggs/issues/1148