### PR TITLE
Include jq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM        openjdk:16-slim
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 RUN apt-get update -y \
- && apt-get install -y curl ca-certificates openssl git tar sqlite fontconfig tzdata iproute2 libfreetype6 \
+ && apt-get install -y curl ca-certificates openssl git tar sqlite fontconfig tzdata iproute2 libfreetype6 jq \
  && useradd -d /home/container -m container
  
 USER container


### PR DESCRIPTION
`jq` can be useful for those who prefer to automate updates after parsing a certain updates API.

Let it be known that automatic updates of Minecraft software are not recommended for the faint of heart.