### PR TITLE
Added OpenJDK 17 Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# ----------------------------------
+# Pterodactyl Core Dockerfile
+# Environment: Java (glibc support)
+# Minimum Panel Version: 0.6.0
+# ----------------------------------
+FROM        openjdk:15-slim
+
+LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+
+RUN apt-get update -y \
+ && apt-get install -y curl ca-certificates openssl git tar sqlite fontconfig tzdata iproute2 \
+ && useradd -d /home/container -m container
+ 
+USER container
+ENV  USER=container HOME=/home/container
+
+USER        container
+ENV         USER=container HOME=/home/container
+
+WORKDIR     /home/container
+
+COPY        ./entrypoint.sh /entrypoint.sh
+
+CMD         ["/bin/bash", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM        openjdk:16-slim
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 RUN apt-get update -y \
- && apt-get install -y curl ca-certificates openssl git tar sqlite fontconfig tzdata iproute2 \
+ && apt-get install -y curl ca-certificates openssl git tar sqlite fontconfig tzdata iproute2 libfreetype6 \
  && useradd -d /home/container -m container
  
 USER container

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM        openjdk:16-slim
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 RUN apt-get update -y \
- && apt-get install -y curl ca-certificates openssl git tar sqlite fontconfig tzdata iproute2 libfreetype6 \
+ && apt-get install -y curl ca-certificates openssl git tar sqlite fontconfig tzdata iproute2 libfreetype6 jq \
  && useradd -d /home/container -m container
  
 USER container

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Environment: Java (glibc support)
 # Minimum Panel Version: 0.6.0
 # ----------------------------------
-FROM        openjdk:15-slim
+FROM        openjdk:16-slim
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Environment: Java (glibc support)
 # Minimum Panel Version: 0.6.0
 # ----------------------------------
-FROM        openjdk:16-slim
+FROM        openjdk:17.0.1-slim
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash 
+cd /home/container
+
+# Output Current Java Version
+java -version
+
+# Make internal Docker IP address available to processes.
+export INTERNAL_IP=`ip route get 1 | awk '{print $NF;exit}'`
+
+# Replace Startup Variables
+MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
+echo ":/home/container$ ${MODIFIED_STARTUP}"
+
+# Run the Server
+eval ${MODIFIED_STARTUP}


### PR DESCRIPTION
added an openJDK 17 image, the minimum java for Minecraft 1.18.